### PR TITLE
Locale support using i18next

### DIFF
--- a/e2e/cypress/integration/sideview.spec.ts
+++ b/e2e/cypress/integration/sideview.spec.ts
@@ -24,7 +24,9 @@ describe('sideview initial state', () => {
 
     it('left view should be active', () => {
         cy.get('#view_0').should('have.class', 'active');
-        //
+    });
+
+    it('nav buttons are disabled', () => {
         cy.get('#view_0 [data-cy-backward]').should('be.disabled');
         cy.get('#view_0 [data-cy-forward]').should('be.disabled');
         cy.get('#view_0 [data-cy-paste-bt]').should('be.disabled');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,21 @@
       "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@blueprintjs/core": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.6.1.tgz",
@@ -73,6 +88,12 @@
         "@types/node": "*"
       }
     },
+    "@types/i18next": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@types/i18next/-/i18next-12.1.0.tgz",
+      "integrity": "sha512-qLyqTkp3ZKHsSoX8CNVYcTyTkxlm0aRCUpaUVetgkSlSpiNCdWryOgaYwgbO04tJIfLgBXPcy0tJ3Nl/RagllA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -113,6 +134,15 @@
       "requires": {
         "@types/node": "*",
         "@types/react": "*"
+      }
+    },
+    "@types/react-i18next": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-i18next/-/react-i18next-8.1.0.tgz",
+      "integrity": "sha512-d4xhcjX5b3roNMObRNMfb1HinHQlQLPo8xlDj60dnHeeAw2bBymR2cy/l1giJpHzo/ZFgSvgVUvIWr4kCrenCg==",
+      "dev": true,
+      "requires": {
+        "react-i18next": "*"
       }
     },
     "@webassemblyjs/ast": {
@@ -4005,6 +4035,14 @@
         }
       }
     },
+    "html-parse-stringify2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
+      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+      "requires": {
+        "void-elements": "^2.0.1"
+      }
+    },
     "html-webpack-plugin": {
       "version": "3.2.0",
       "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
@@ -4132,6 +4170,21 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "i18next": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-13.0.0.tgz",
+      "integrity": "sha512-P8SDA5PN4bI5/ZdLE2AlanZhU+eXh31icrojQvbGcG7jovoDoz79eKY9mSgQ0LAeuDFKAw4Vl4mGf1/EWGFACg=="
+    },
+    "i18next-browser-languagedetector": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-2.2.4.tgz",
+      "integrity": "sha512-wPbtH18FdOuB245I8Bhma5/XSDdN/HpYlX+wga1eMy+slhaFQSnrWX6fp+aYSL2eEuj0RlfHeEVz6Fo/lxAj6A=="
+    },
+    "i18next-electron-language-detector": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/i18next-electron-language-detector/-/i18next-electron-language-detector-0.0.10.tgz",
+      "integrity": "sha512-l/CdtK5i6BB7h5OGKadUK+Q0q4e4EYXZSDV+Hetxjdv4C8RoYPNbqfTIpcc4RpIO3Dty05Xt8TxV+HyFd6opeA=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -6145,6 +6198,32 @@
         "schedule": "^0.5.0"
       }
     },
+    "react-i18next": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-8.4.0.tgz",
+      "integrity": "sha512-zIO/bc1L0UUGdaws2y40cTiSQHuQud5e9SSodYM6MTzhJTI3iayxCCdgvotblOLM4taOD77Ct2/fUbheQIhyeg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "0.2.3",
+        "hoist-non-react-statics": "3.0.1",
+        "html-parse-stringify2": "2.0.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
+          "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
+          "requires": {
+            "react-is": "^16.3.2"
+          }
+        }
+      }
+    },
+    "react-is": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -7404,6 +7483,11 @@
         }
       }
     },
+    "uninstall": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/uninstall/-/uninstall-0.0.0.tgz",
+      "integrity": "sha1-ED5uN+nFLshXVCzSWQI9ccej+ys="
+    },
     "union": {
       "version": "0.4.6",
       "resolved": "http://registry.npmjs.org/union/-/union-0.4.6.tgz",
@@ -7686,6 +7770,11 @@
       "requires": {
         "indexof": "0.0.1"
       }
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "warning": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "license": "ISC",
   "devDependencies": {
     "@types/del": "^3.0.1",
+    "@types/i18next": "^12.1.0",
+    "@types/react-i18next": "^8.1.0",
     "awesome-typescript-loader": "^5.2.1",
     "aws-sdk": "^2.332.0",
     "css-loader": "^1.0.0",
@@ -49,11 +51,16 @@
     "ftp": "github:warpdesign/node-ftp#master",
     "ftp-ts": "^1.0.19",
     "get-folder-size": "^2.0.0",
+    "i18next": "^13.0.0",
+    "i18next-browser-languagedetector": "^2.2.4",
+    "i18next-electron-language-detector": "0.0.10",
     "mkdirp": "^0.5.1",
     "mobx": "^3.2.1",
     "mobx-react": "^4.2.2",
     "mobx-react-devtools": "^4.2.15",
     "react": "^16.5.2",
-    "react-dom": "^16.5.2"
+    "react-dom": "^16.5.2",
+    "react-i18next": "^8.4.0",
+    "uninstall": "0.0.0"
   }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -193,12 +193,8 @@ class App extends React.Component<WithNamespaces, IState> {
         console.log('changing language to en');
         i18next.changeLanguage('en', (err, t2) => {
             if (err) {
-                console.log('oops, error', err);
+                console.warn('oops, error changing language to en', err);
             }
-            const { t } = this.props;
-            console.log(t2('NAV.EXPLORER'));
-            console.log(t('NAV.EXPLORER'));
-            console.log(i18next.t('NAV.EXPLORER'));
         });
     }
 
@@ -208,11 +204,7 @@ class App extends React.Component<WithNamespaces, IState> {
         const badgeText = count && (count + '') || '';
         const badgeProgress = this.appState.totalTransferProgress;
         const { t } = this.props;
-        // console.log(t('test', { compteur: 10 }));
-        // console.log(t('COMMON2.TEST', { count: 10 }));
-        // console.log(t('COMMON.Toto', { count: 10 }));
-        // debugger;
-        // console.log(t('DIALOG.QUIT.CONTENT', { count: 2 }));
+
         return (
             <Provider appState={this.appState}>
                 <React.Fragment>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,7 +9,7 @@ import { LogUI, Logger } from "./Log";
 import { Downloads } from "./Downloads";
 import { Badge } from "./Badge";
 import { ipcRenderer } from "electron";
-import { withNamespaces, WithNamespaces } from 'react-i18next';
+import { withNamespaces, WithNamespaces, Trans } from 'react-i18next';
 
 require("@blueprintjs/core/lib/css/blueprint.css");
 require("@blueprintjs/icons/lib/css/blueprint-icons.css");
@@ -169,19 +169,19 @@ class App extends React.Component<WithNamespaces, IState> {
             <Hotkey
                 global={true}
                 combo="q"
-                label={t('SHORTCUT_EXIT')}
+                label={t('SHORTCUT.MAIN.QUIT')}
                 onKeyDown={this.onExitComboDown}
             />
             <Hotkey
                 global={true}
                 combo="mod + q"
-                label={t('SHORTCUT_EXIT')}
+                label={t('SHORTCUT.MAIN.QUIT')}
                 onKeyDown={this.onExitComboDown}
             />
             <Hotkey
                 global={true}
                 combo="mod + r"
-                label={t('SHORTCUT_RELOAD_VIEW')}
+                label={t('SHORTCUT.MAIN.RELOAD_VIEW')}
                 preventDefault={true}
                 onKeyDown={this.onReloadFileView}
             />
@@ -199,23 +199,25 @@ class App extends React.Component<WithNamespaces, IState> {
             <Provider appState={this.appState}>
                 <React.Fragment>
                     <Alert
-                        cancelButtonText={t('BT_KEEP_TRANSFERS')}
-                        confirmButtonText={t('BT_STOP_TRANSFERS_QUIT')}
+                        cancelButtonText={t('DIALOG.QUIT.BT_KEEP_TRANSFERS')}
+                        confirmButtonText={t('DIALOG.QUIT.BT_STOP_TRANSFERS')}
                         icon="warning-sign"
                         intent={Intent.WARNING}
                         onClose={this.onExitDialogClose}
                         isOpen={isExitDialogOpen}
                     >
                         <p>
-                            There are <b>{`${badgeSize}`}</b> transfers <b>in progress</b>.<br /><br />Exiting the app now will <b>cancel</b> the downloads:<br /> are you should you want to exit now?
+                            <Trans i18nKey="DIALOG.QUIT.CONTENT">
+                                There are <b>{{ badgeSize }}</b> transfers <b>in progress</b>.<br /><br />Exiting the app now will <b>cancel</b> the downloads.
+                            </Trans>
                     </p>
                     </Alert>
                     <Navbar>
                         <Navbar.Group align={Alignment.LEFT}>
                             <Navbar.Heading>React-explorer</Navbar.Heading>
                             <Navbar.Divider />
-                            <Button className="bp3-minimal" icon="home" text="Explorer" onClick={this.navClick} intent={isExplorer ? Intent.PRIMARY : 'none'} />
-                            <Button style={{ position: 'relative' }} className="bp3-minimal" icon="download" onClick={this.navClick} intent={!isExplorer ? Intent.PRIMARY : 'none'}>Transfers<Badge intent="none" text={badgeText} progress={badgeProgress} /></Button>
+                            <Button className="bp3-minimal" icon="home" text={t('NAV.EXPLORER')} onClick={this.navClick} intent={isExplorer ? Intent.PRIMARY : 'none'} />
+                            <Button style={{ position: 'relative' }} className="bp3-minimal" icon="download" onClick={this.navClick} intent={!isExplorer ? Intent.PRIMARY : 'none'}>{t('NAV.TRANSFERS')}<Badge intent="none" text={badgeText} progress={badgeProgress} /></Button>
                         </Navbar.Group>
                         <Navbar.Group align={Alignment.RIGHT}>
                             <Navbar.Divider />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,7 +8,8 @@ import { SideView } from "./SideView";
 import { LogUI, Logger } from "./Log";
 import { Downloads } from "./Downloads";
 import { Badge } from "./Badge";
-import { ipcRenderer, remote } from "electron";
+import { ipcRenderer } from "electron";
+import { withNamespaces, WithNamespaces } from 'react-i18next';
 
 require("@blueprintjs/core/lib/css/blueprint.css");
 require("@blueprintjs/icons/lib/css/blueprint-icons.css");
@@ -32,15 +33,16 @@ declare global {
     }
 }
 
+
 @observer
 @HotkeysTarget
-export class ReactApp extends React.Component<{}, IState> {
+class App extends React.Component<WithNamespaces, IState> {
     private appState: AppState;
     private lastTimeStamp: any = 0;
     private exitTimeout: any = 0;
     private exitMode = false;
 
-    constructor(props = {}) {
+    constructor(props: WithNamespaces) {
         super(props);
 
         this.state = { isExplorer: true, activeView: 0, isExitDialogOpen: false };
@@ -161,23 +163,25 @@ export class ReactApp extends React.Component<{}, IState> {
     }
 
     public renderHotkeys() {
+        const t = this.props.t;
+
         return <Hotkeys>
             <Hotkey
                 global={true}
                 combo="q"
-                label="Exit react-ftp"
+                label={t('SHORTCUT_EXIT')}
                 onKeyDown={this.onExitComboDown}
             />
             <Hotkey
                 global={true}
                 combo="mod + q"
-                label="Exit react-ftp"
+                label={t('SHORTCUT_EXIT')}
                 onKeyDown={this.onExitComboDown}
             />
             <Hotkey
                 global={true}
                 combo="mod + r"
-                label="Reload current view"
+                label={t('SHORTCUT_RELOAD_VIEW')}
                 preventDefault={true}
                 onKeyDown={this.onReloadFileView}
             />
@@ -189,13 +193,14 @@ export class ReactApp extends React.Component<{}, IState> {
         const badgeSize = this.appState.pendingTransfers;
         const badgeText = badgeSize && (badgeSize + '') || '';
         const badgeProgress = this.appState.totalTransferProgress;
+        const { t } = this.props;
 
         return (
             <Provider appState={this.appState}>
                 <React.Fragment>
                     <Alert
-                        cancelButtonText="Keep transfers"
-                        confirmButtonText="Exit & Cancel transfers"
+                        cancelButtonText={t('BT_KEEP_TRANSFERS')}
+                        confirmButtonText={t('BT_STOP_TRANSFERS_QUIT')}
                         icon="warning-sign"
                         intent={Intent.WARNING}
                         onClose={this.onExitDialogClose}
@@ -229,3 +234,6 @@ export class ReactApp extends React.Component<{}, IState> {
     }
 }
 
+const ReactApp = withNamespaces()(App);
+
+export { ReactApp }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -190,11 +190,15 @@ class App extends React.Component<WithNamespaces, IState> {
 
     render() {
         const { isExplorer, activeView, isExitDialogOpen } = this.state;
-        const badgeSize = this.appState.pendingTransfers;
-        const badgeText = badgeSize && (badgeSize + '') || '';
+        const count = this.appState.pendingTransfers + 1;
+        const badgeText = count && (count + '') || '';
         const badgeProgress = this.appState.totalTransferProgress;
         const { t } = this.props;
-
+        // console.log(t('test', { compteur: 10 }));
+        // console.log(t('COMMON2.TEST', { count: 10 }));
+        // console.log(t('STATUS.CPTOOLTIP', { numSelected: 10 }));
+        // debugger;
+        // console.log(t('STATUS.CPTOOLTIP', { count: 10 }));
         return (
             <Provider appState={this.appState}>
                 <React.Fragment>
@@ -208,7 +212,7 @@ class App extends React.Component<WithNamespaces, IState> {
                     >
                         <p>
                             <Trans i18nKey="DIALOG.QUIT.CONTENT">
-                                There are <b>{{ badgeSize }}</b> transfers <b>in progress</b>.<br /><br />Exiting the app now will <b>cancel</b> the downloads.
+                                There are <b>{{ count }}</b> transfers <b>in progress</b>.<br /><br />Exiting the app now will <b>cancel</b> the downloads.
                             </Trans>
                     </p>
                     </Alert>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,8 @@ import { Downloads } from "./Downloads";
 import { Badge } from "./Badge";
 import { ipcRenderer } from "electron";
 import { withNamespaces, WithNamespaces, Trans } from 'react-i18next';
+import { updateTranslations } from '../utils/formatBytes';
+import i18next from '../locale/i18n';
 
 require("@blueprintjs/core/lib/css/blueprint.css");
 require("@blueprintjs/icons/lib/css/blueprint-icons.css");
@@ -33,7 +35,6 @@ declare global {
     }
 }
 
-
 @observer
 @HotkeysTarget
 class App extends React.Component<WithNamespaces, IState> {
@@ -56,7 +57,7 @@ class App extends React.Component<WithNamespaces, IState> {
             window.appState = this.appState;
         }
 
-        Logger.success(`React-FTP - CY: ${ENV.CY} NODE_ENV: ${ENV.NODE_ENV}`);
+        Logger.success(`React-FTP - CY: ${ENV.CY} - NODE_ENV: ${ENV.NODE_ENV} - lang: ${i18next.language}`);
         // Logger.warn('React-FTP', remote.app.getVersion());
         // Logger.error('React-FTP', remote.app.getVersion());
     }
@@ -188,6 +189,20 @@ class App extends React.Component<WithNamespaces, IState> {
         </Hotkeys>;
     }
 
+    changeLanguage = () => {
+        console.log('changing language to en');
+        i18next.changeLanguage('en', (err, t2) => {
+            if (err) {
+                console.log('oops, error', err);
+            }
+            const { t } = this.props;
+            console.log(t2('NAV.EXPLORER'));
+            console.log(t('NAV.EXPLORER'));
+            console.log(i18next.t('NAV.EXPLORER'));
+            debugger;
+        });
+    }
+
     render() {
         const { isExplorer, activeView, isExitDialogOpen } = this.state;
         const count = this.appState.pendingTransfers;
@@ -225,7 +240,7 @@ class App extends React.Component<WithNamespaces, IState> {
                         </Navbar.Group>
                         <Navbar.Group align={Alignment.RIGHT}>
                             <Navbar.Divider />
-                            <Button className="bp3-minimal" icon="cog" />
+                            <Button className="bp3-minimal" onClick={this.changeLanguage} icon="cog" />
                         </Navbar.Group>
                     </Navbar>
                     <div onClickCapture={this.handleClick} className="main">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -190,15 +190,15 @@ class App extends React.Component<WithNamespaces, IState> {
 
     render() {
         const { isExplorer, activeView, isExitDialogOpen } = this.state;
-        const count = this.appState.pendingTransfers + 1;
+        const count = this.appState.pendingTransfers;
         const badgeText = count && (count + '') || '';
         const badgeProgress = this.appState.totalTransferProgress;
         const { t } = this.props;
         // console.log(t('test', { compteur: 10 }));
         // console.log(t('COMMON2.TEST', { count: 10 }));
-        // console.log(t('STATUS.CPTOOLTIP', { numSelected: 10 }));
+        // console.log(t('COMMON.Toto', { count: 10 }));
         // debugger;
-        // console.log(t('STATUS.CPTOOLTIP', { count: 10 }));
+        // console.log(t('DIALOG.QUIT.CONTENT', { count: 2 }));
         return (
             <Provider appState={this.appState}>
                 <React.Fragment>
@@ -211,7 +211,7 @@ class App extends React.Component<WithNamespaces, IState> {
                         isOpen={isExitDialogOpen}
                     >
                         <p>
-                            <Trans i18nKey="DIALOG.QUIT.CONTENT">
+                            <Trans i18nKey="DIALOG.QUIT.CONTENT" count={count}>
                                 There are <b>{{ count }}</b> transfers <b>in progress</b>.<br /><br />Exiting the app now will <b>cancel</b> the downloads.
                             </Trans>
                     </p>
@@ -242,4 +242,4 @@ class App extends React.Component<WithNamespaces, IState> {
 
 const ReactApp = withNamespaces()(App);
 
-export { ReactApp }
+export { ReactApp };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -199,7 +199,6 @@ class App extends React.Component<WithNamespaces, IState> {
             console.log(t2('NAV.EXPLORER'));
             console.log(t('NAV.EXPLORER'));
             console.log(i18next.t('NAV.EXPLORER'));
-            debugger;
         });
     }
 

--- a/src/components/AppAlert.tsx
+++ b/src/components/AppAlert.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Alert, IAlertProps } from '@blueprintjs/core';
 import { Deferred } from '../utils/deferred';
+import i18next from '../locale/i18n';
 
 type Message = React.ReactNode | string;
 
@@ -56,6 +57,10 @@ class Alerter extends React.Component<{}, IAlerterState> {
 
     private renderAlert() {
         const { message, ...alertProps } = this.state;
+
+        if (!alertProps.confirmButtonText) {
+            alertProps.confirmButtonText = i18next.t('COMMON.OK');
+        }
 
         return <Alert {...alertProps}>{message}</Alert>;
     }

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -16,8 +16,15 @@ export interface IToasterOpts {
     timeout?: number
 }
 
+let lastToast = '';
+
 export const AppToaster = {
-    show: (opts:IToasterOpts, key?:string):string => {
-        return MyToaster.show({timeout: TOAST_TIMEOUT, ...opts}, key);
+    show: (opts: IToasterOpts, key?: string, dismissPrev = false): string => {
+        if (dismissPrev) {
+            MyToaster.dismiss(lastToast);
+        }
+
+        lastToast = MyToaster.show({ timeout: TOAST_TIMEOUT, ...opts }, key);
+        return lastToast;
     }
 }

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -5,7 +5,7 @@ import { IconName } from "@blueprintjs/icons";
 const TOAST_TIMEOUT = 2000;
 
 const MyToaster = Toaster.create({
-    className: "recipe-toaster",
+    className: "bp3-toaster",
     position: Position.TOP,
 });
 

--- a/src/components/Downloads.tsx
+++ b/src/components/Downloads.tsx
@@ -4,8 +4,10 @@ import { AppState } from '../state/appState';
 import { inject } from 'mobx-react';
 import { Batch } from '../transfers/batch';
 import { reaction, toJS, IReactionDisposer } from 'mobx';
+import { withNamespaces, WithNamespaces } from 'react-i18next';
+import { formatBytes } from '../utils/formatBytes';
 
-interface IProps {
+interface IProps extends WithNamespaces{
     hide: boolean;
 }
 
@@ -23,7 +25,7 @@ interface IState {
 }
 
 @inject('appState')
-export class Downloads extends React.Component<IProps, IState> {
+class DownloadsClass extends React.Component<IProps, IState> {
     private disposer: IReactionDisposer;
     private appState: AppState;
 
@@ -85,7 +87,7 @@ export class Downloads extends React.Component<IProps, IState> {
 
         for (let transfer of transfers) {
             let i = transfer.id;
-            const sizeStr = transfer.status !== 'calculating' && (transfer.size + ' bytes') || '';
+            const sizeStr = transfer.status !== 'calculating' && formatBytes(transfer.size) || '';
 
             const node: ITreeNode =
             {
@@ -123,6 +125,7 @@ export class Downloads extends React.Component<IProps, IState> {
     renderTransferTree() {
         console.log('render');
         const { nodes } = this.state;
+        const { t } = this.props;
 
         console.log('render downloads tree');
 
@@ -138,9 +141,12 @@ export class Downloads extends React.Component<IProps, IState> {
             );
         } else {
             return (
-                <Callout className="downloads" title="No downloads yet :)" intent="success" icon="tick-circle">
-                    This section will help you monitor <Code>transfers</Code> that are in progress.
-                </Callout>
+                <div className="downloads empty">
+                    <Icon iconSize={80} icon="document" color="#d9dde0"></Icon>
+                    <p>
+                        {t('DOWNLOADS.EMPTY_TITLE')}
+                    </p>
+                </div>
             );
         }
 
@@ -163,3 +169,7 @@ export class Downloads extends React.Component<IProps, IState> {
         }
     }
 }
+
+const Downloads = withNamespaces()(DownloadsClass);
+
+export { Downloads };

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -3,13 +3,13 @@ import { inject } from 'mobx-react';
 import { reaction, toJS, IReactionDisposer } from 'mobx';
 import { Classes, Button, ITreeNode, Tooltip, Tree, Intent } from "@blueprintjs/core";
 import { AppState } from "../state/appState";
-import { AppToaster } from './AppToaster';
 // TODO: remove any calls to shell
 import { File } from "../services/Fs";
 import { shell } from 'electron';
 import { Logger } from "./Log";
 import { FileState } from "../state/fileState";
 import { withNamespaces, WithNamespaces } from 'react-i18next';
+import { formatBytes } from '../utils/formatBytes';
 
 const REGEX_EXTENSION = /\.(?=[^0-9])/;
 
@@ -50,14 +50,11 @@ export class FileListClass extends React.Component<IProps, FileListState> {
     private editingFile: File;
     private clickTimeout: any;
     private disposer: IReactionDisposer;
-    private ByteSizes = new Array<string>();
 
     constructor(props: IProps) {
         super(props);
 
         const { t } = this.props;
-        const translations = t('COMMON.SIZE', { returnObjects: true });
-        this.ByteSizes = Object.keys(translations).map((key) => translations[key]);
 
         const { fileCache } = this.injected;
 
@@ -88,26 +85,6 @@ export class FileListClass extends React.Component<IProps, FileListState> {
             });
     }
 
-    // took this from stack overflow: https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
-    private sizeExtension(bytes:number):string {
-        const i = bytes > 0 ? Math.floor(Math.log2(bytes)/10) : 0;
-        const num = (bytes/Math.pow(1024, i));
-
-        if (!i) {
-            return num > 1 ? (num + ' ' + this.ByteSizes[1]) : (num + ' ' + this.ByteSizes[0]);
-        } else {
-            return (num.toFixed(2)) + ' ' + this.ByteSizes[i+1];
-        }
-
-        /*
-        const i = bytes > 0 ? Math.floor(Math.log2(bytes)/10) : 0;
-        const num = (bytes/Math.pow(1024, i));
-
-        if
-        return  (i > 0 ? num.toFixed(2) : (num | 0)) + ' ' + ['Bytes','Kb','Mb','Gb','Tb'][i];
-        */
-    }
-
     private buildNodes = (files:File[]): ITreeNode<{}>[] => {
         return files
             .sort((file1, file2) => {
@@ -126,7 +103,7 @@ export class FileListClass extends React.Component<IProps, FileListState> {
                     label: file.fullname,
                     nodeData: file,
                     className: file.fullname !== '..' && file.fullname.startsWith('.') && 'isHidden',
-                    secondaryLabel: !file.isDir && (<div className="bp3-text-small">{this.sizeExtension(file.length)}</div>) || ''
+                    secondaryLabel: !file.isDir && (<div className="bp3-text-small">{formatBytes(file.length)}</div>) || ''
                 };
             return res;
         });

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -9,6 +9,7 @@ import { File } from "../services/Fs";
 import { shell } from 'electron';
 import { Logger } from "./Log";
 import { FileState } from "../state/fileState";
+import { withNamespaces, WithNamespaces } from 'react-i18next';
 
 const REGEX_EXTENSION = /\.(?=[^0-9])/;
 
@@ -25,7 +26,7 @@ enum KEYS {
 
 const CLICK_DELAY = 300;
 
-interface IProps{
+interface IProps extends WithNamespaces{
     onUpdate?: () => void;
     onRender?: () => void;
 }
@@ -43,16 +44,20 @@ interface InjectedProps extends IProps {
 }
 
 @inject('appState', 'fileCache')
-export class FileList extends React.Component<IProps, FileListState> {
+export class FileListClass extends React.Component<IProps, FileListState> {
     private cache: FileState;
     private editingElement: HTMLElement;
     private editingFile: File;
     private clickTimeout: any;
     private disposer: IReactionDisposer;
-    private firstRender = true;
+    private ByteSizes = new Array<string>();
 
     constructor(props: IProps) {
         super(props);
+
+        const { t } = this.props;
+        const translations = t('COMMON.SIZE', { returnObjects: true });
+        this.ByteSizes = Object.keys(translations).map((key) => translations[key]);
 
         const { fileCache } = this.injected;
 
@@ -88,7 +93,19 @@ export class FileList extends React.Component<IProps, FileListState> {
         const i = bytes > 0 ? Math.floor(Math.log2(bytes)/10) : 0;
         const num = (bytes/Math.pow(1024, i));
 
+        if (!i) {
+            return num > 1 ? (num + ' ' + this.ByteSizes[1]) : (num + ' ' + this.ByteSizes[0]);
+        } else {
+            return (num.toFixed(2)) + ' ' + this.ByteSizes[i+1];
+        }
+
+        /*
+        const i = bytes > 0 ? Math.floor(Math.log2(bytes)/10) : 0;
+        const num = (bytes/Math.pow(1024, i));
+
+        if
         return  (i > 0 ? num.toFixed(2) : (num | 0)) + ' ' + ['Bytes','Kb','Mb','Gb','Tb'][i];
+        */
     }
 
     private buildNodes = (files:File[]): ITreeNode<{}>[] => {
@@ -311,3 +328,7 @@ export class FileList extends React.Component<IProps, FileListState> {
         // }
     }
 }
+
+const FileList = withNamespaces()(FileListClass);
+
+export { FileList };

--- a/src/components/FileMenu.tsx
+++ b/src/components/FileMenu.tsx
@@ -3,8 +3,9 @@ import { Menu, MenuItem, MenuDivider } from "@blueprintjs/core";
 import { observer, inject } from "mobx-react";
 import { AppState } from "../state/appState";
 import { File } from "../services/Fs";
+import { withNamespaces, WithNamespaces } from 'react-i18next';
 
-interface IFileMenuProps {
+interface IFileMenuProps extends WithNamespaces {
     onFileAction: (action: string) => any;
     selectedItems: File[];
 };
@@ -15,7 +16,7 @@ interface InjectedProps extends IFileMenuProps{
 
 @inject('appState')
 @observer
-export class FileMenu extends React.Component<IFileMenuProps>{
+export class FileMenuClass extends React.Component<IFileMenuProps>{
     constructor (props: IFileMenuProps){
         super(props);
     }
@@ -48,17 +49,21 @@ export class FileMenu extends React.Component<IFileMenuProps>{
     public render() {
         const { appState } = this.injected;
         const clipboardLength = appState.clipboard.files.length;
-        const { selectedItems } = this.props;
+        const { selectedItems, t } = this.props;
 
         return (
         <React.Fragment>
                 <Menu>
-                <MenuItem text="New Folder" icon="folder-new" onClick={this.onNewfolder}/>
+                <MenuItem text={t('COMMON.MAKEDIR')} icon="folder-new" onClick={this.onNewfolder}/>
                 <MenuDivider />
-                <MenuItem text={`Paste ${clipboardLength} item(s)`} icon="duplicate" onClick={this.onPaste} disabled={!clipboardLength} />
-                <MenuItem text={`Delete ${selectedItems.length} item(s)`} onClick={this.onDelete} intent={selectedItems.length && "danger" || "none"} icon="delete" disabled={!selectedItems.length} />
+                <MenuItem text={t('FILEMENU.PASTE', {count: clipboardLength})} icon="duplicate" onClick={this.onPaste} disabled={!clipboardLength} />
+                <MenuItem text={t('FILEMENU.DELETE', { count: selectedItems.length })} onClick={this.onDelete} intent={selectedItems.length && "danger" || "none"} icon="delete" disabled={!selectedItems.length} />
             </Menu>
         </React.Fragment>
         )
     }
 }
+
+const FileMenu = withNamespaces()(FileMenuClass);
+
+export { FileMenu };

--- a/src/components/FileMenu.tsx
+++ b/src/components/FileMenu.tsx
@@ -56,7 +56,8 @@ export class FileMenuClass extends React.Component<IFileMenuProps>{
                 <Menu>
                 <MenuItem text={t('COMMON.MAKEDIR')} icon="folder-new" onClick={this.onNewfolder}/>
                 <MenuDivider />
-                <MenuItem text={t('FILEMENU.PASTE', {count: clipboardLength})} icon="duplicate" onClick={this.onPaste} disabled={!clipboardLength} />
+                <MenuItem text={t('FILEMENU.PASTE', { count: clipboardLength })} icon="duplicate" onClick={this.onPaste} disabled={!clipboardLength} />
+                <MenuDivider />
                 <MenuItem text={t('FILEMENU.DELETE', { count: selectedItems.length })} onClick={this.onDelete} intent={selectedItems.length && "danger" || "none"} icon="delete" disabled={!selectedItems.length} />
             </Menu>
         </React.Fragment>

--- a/src/components/Log.tsx
+++ b/src/components/Log.tsx
@@ -154,3 +154,13 @@ export class LogUI extends React.Component<any, LogUIState> {
         )
     }
 }
+
+export function log(target:any, key:string, descriptor:PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    descriptor.value = function (...args:any[]) {
+        console.log(`${key} was called with:`, ...args);
+        var result = originalMethod.apply(this, arguments);
+        return result;
+    };
+    return descriptor;
+}

--- a/src/components/LoginDialog.tsx
+++ b/src/components/LoginDialog.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 import { Dialog, Classes, Intent, Button, InputGroup, FormGroup, Colors} from "@blueprintjs/core";
 import { inject } from "mobx-react";
 import { FileState } from "../state/fileState";
+import { withNamespaces, WithNamespaces } from "react-i18next";
 
-interface ILoginProps {
+interface ILoginProps extends WithNamespaces {
     isOpen: boolean;
     onClose?: (user: string, password: string) => void
     onValidation: (dir: string) => boolean
@@ -31,7 +32,7 @@ interface ILoginState {
 const ENTER_KEY = 13;
 
 @inject('fileCache')
-export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
+class LoginDialogClass extends React.Component<ILoginProps, ILoginState> {
     private input: HTMLInputElement | null = null;
 
     constructor(props:any) {
@@ -125,6 +126,7 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
 
     public render() {
         const { user, password, busy, error, port, server } = this.state;
+        const { t } = this.props;
 
         if (error) {
             console.log(error.code, error.message);
@@ -133,7 +135,7 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
         return(
             <Dialog
             icon="globe-network"
-            title={`Login to ${server}`}
+            title={t('DIALOG.LOGIN.TITLE', {server: server})}
             isOpen={this.props.isOpen}
             autoFocus={true}
             enforceFocus={true}
@@ -143,15 +145,15 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
             className="loginDialog"
         >
                 <div className={Classes.DIALOG_BODY}>
-                    {error && (<p className="error" style={{ backgroundColor: Colors.RED4 }}>{error.message} (code {error.code})</p>)}
+                    {error && (<p className="error" style={{ backgroundColor: Colors.RED4 }}>{t('ERRORS.GENERIC', { error })}</p>)}
                     <FormGroup
                         inline={true}
                         labelFor="server"
-                        labelInfo="server"
+                        labelInfo={t('DIALOG.LOGIN.SERVER')}
                     >
                         <InputGroup
                             onChange={this.onInputChange}
-                            placeholder="Enter server"
+                            placeholder={t('DIALOG.LOGIN.SERVER_NAME')}
                             disabled={busy}
                             value={server}
                             id="server"
@@ -162,12 +164,12 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
                 <FormGroup
                     inline={true}
                     labelFor="user"
-                    labelInfo="username"
-                    helperText={(<span>Leave empty for <em>anonymous</em> login</span>)}
+                    labelInfo={t('DIALOG.LOGIN.USERNAME')}
+                        helperText={(<span>{t('DIALOG.LOGIN.HINT_USERNAME')}</span>)}
                 >
                     <InputGroup
                         onChange={this.onInputChange}
-                            placeholder="Enter username"
+                            placeholder={t('DIALOG.LOGIN.USERINPUT')}
                             disabled={busy}
                             value={user}
                             inputRef={this.refHandler}
@@ -180,12 +182,12 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
                     <FormGroup
                         inline={true}
                         labelFor="password"
-                        labelInfo="password"
-                        helperText="Required for non-anonymous login"
+                        labelInfo={t('DIALOG.LOGIN.PASSWORD')}
+                        helperText={t('DIALOG.LOGIN.HINT_PASSWORD')}
                     >
                         <InputGroup
                             onChange={this.onInputChange}
-                            placeholder="Enter password"
+                            placeholder={t('DIALOG.LOGIN.PASSWORDINPUT')}
                             disabled={busy}
                             value={password}
                             id="password"
@@ -197,7 +199,7 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
                     <FormGroup
                         inline={true}
                         labelFor="port"
-                        labelInfo="port"
+                        labelInfo={t('DIALOG.LOGIN.PORT')}
                     >
                         <InputGroup
                             onChange={this.onInputChange}
@@ -212,9 +214,9 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
             </div>
             <div className={Classes.DIALOG_FOOTER}>
                 <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                    <Button onClick={this.cancelClose} disabled={busy}>Cancel</Button>
+                        <Button onClick={this.cancelClose} disabled={busy}>{t('COMMON.CANCEL')}</Button>
                         <Button loading={busy} intent={Intent.PRIMARY} onClick={this.onLogin} disabled={!this.canLogin()}>
-                        {'Login'}
+                        {t('DIALOG.LOGIN.LOGIN')}
                     </Button>
                 </div>
             </div>
@@ -222,3 +224,7 @@ export class LoginDialog extends React.Component<ILoginProps, ILoginState> {
         )
     }
 }
+
+const LoginDialog = withNamespaces()(LoginDialogClass);
+
+export { LoginDialog };

--- a/src/components/MakedirDialog.tsx
+++ b/src/components/MakedirDialog.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Dialog, Classes, Intent, Button, InputGroup, FormGroup, Label, Checkbox } from "@blueprintjs/core";
 import { debounce } from "../utils/debounce";
+import { withNamespaces, WithNamespaces } from "react-i18next";
 
-interface IMakedirProps {
+interface IMakedirProps extends WithNamespaces {
     isOpen: boolean;
     parentPath: string;
     onClose?: (dirName: string, navigate: boolean) => void
@@ -21,7 +22,7 @@ const ENTER_KEY = 13;
 const META_KEY = 91;
 const ReadFolderKey = process.platform === 'darwin' && META_KEY || CTRL_KEY;
 
-export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>{
+class MakedirDialogClass extends React.Component<IMakedirProps, IMakedirState>{
     constructor(props:any) {
         super(props);
 
@@ -112,8 +113,10 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
 
     public render() {
         const { path, valid, ctrlKey } = this.state;
+        const { t } = this.props;
+
         const intent = !valid && 'danger' || 'none';
-        const helperText = !valid && (<span>Folder name not valid</span>) || (<span>&nbsp;</span>);
+        const helperText = !valid && (<span>{t('DIALOG.MAKEDIR.NOT_VALID')}</span>) || (<span>&nbsp;</span>);
         let { parentPath } = this.props;
 
         let sep = '';
@@ -130,7 +133,7 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
         return(
             <Dialog
             icon="folder-new"
-            title="New Folder"
+            title={t('COMMON.MAKEDIR')}
             isOpen={this.props.isOpen}
             autoFocus={true}
             enforceFocus={true}
@@ -139,7 +142,7 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
             onClose={this.cancelClose}
         >
             <div className={Classes.DIALOG_BODY}>
-                <p>Enter a name to create a new folder:</p>
+                    <p>{t('DIALOG.MAKEDIR.TITLE')}</p>
                 <FormGroup
                     helperText={helperText}
                     inline={true}
@@ -148,7 +151,7 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
                 >
                     <InputGroup
                         onChange={this.onPathChange}
-                        placeholder="Enter folder name"
+                        placeholder={t('DIALOG.MAKEDIR.NAME')}
                         value={path}
                         id="directory-input"
                         name="directory-input"
@@ -159,10 +162,10 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
             </div>
             <div className={Classes.DIALOG_FOOTER}>
                 <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                    <Button onClick={this.cancelClose}>Cancel</Button>
+                        <Button onClick={this.cancelClose}>{t('COMMON.CANCEL')}</Button>
 
                         <Button intent={Intent.PRIMARY} onClick={this.onCreate} disabled={!path.length || !valid}>
-                        {!ctrlKey && 'Create' || 'Create & read folder'}
+                            {!ctrlKey && t('DIALOG.MAKEDIR.CREATE') || t('DIALOG.MAKEDIR.CREATE_READ')}
                     </Button>
                 </div>
             </div>
@@ -170,3 +173,7 @@ export class MakedirDialog extends React.Component<IMakedirProps, IMakedirState>
         )
     }
 }
+
+const MakedirDialog = withNamespaces()(MakedirDialogClass);
+
+export { MakedirDialog };

--- a/src/components/SideView.tsx
+++ b/src/components/SideView.tsx
@@ -170,7 +170,7 @@ export class SideView extends React.Component<SideViewProps, SideViewState>{
                 </div>
             );
         } else {
-            return (<div />);
+            return (<React.Fragment></React.Fragment>);
         }
     }
 

--- a/src/components/SideView.tsx
+++ b/src/components/SideView.tsx
@@ -84,7 +84,7 @@ export class SideView extends React.Component<SideViewProps, SideViewState>{
                 message: `${num} element(s) copied to the clipboard`,
                 icon: "tick",
                 intent: Intent.SUCCESS
-            });
+            }, undefined, true);
         }
     }
 

--- a/src/components/Statusbar.tsx
+++ b/src/components/Statusbar.tsx
@@ -4,16 +4,21 @@ import { InputGroup, ControlGroup, Button, ButtonGroup, Popover, Intent, Alert, 
 import { AppState } from "../state/appState";
 import { AppToaster } from "./AppToaster";
 import { FileState } from "../state/fileState";
+import { withNamespaces, WithNamespaces } from 'react-i18next';
 
-interface InjectedProps {
+interface IProps extends WithNamespaces{
+
+};
+
+interface InjectedProps extends IProps {
     fileCache: FileState;
     appState: AppState
 }
 
 @inject('fileCache', 'appState')
 @observer
-export class Statusbar extends React.Component {
-    constructor(props: any) {
+export class StatusbarClass extends React.Component<IProps> {
+    constructor(props: IProps) {
         super(props);
     }
 
@@ -50,9 +55,10 @@ export class Statusbar extends React.Component {
         const numSelected = fileCache.selected.length;
         const iconName = fileCache.getFS().icon as IconName;
         const offline = fileCache.status === 'offline' && 'offline' || '';
+        const { t } = this.props;
 
         const pasteButton = (
-            <Tooltip content={`Copy ${numSelected} file(s) to the clipboard`} disabled={disabled}>
+            <Tooltip content={t('STATUS.CPTOOLTIP', { numSelected })} disabled={disabled}>
                 <Button
                 data-cy-paste-bt
                 disabled={disabled}
@@ -76,3 +82,7 @@ export class Statusbar extends React.Component {
         )
     }
 }
+
+const Statusbar = withNamespaces()(StatusbarClass);
+
+export { Statusbar };

--- a/src/components/Statusbar.tsx
+++ b/src/components/Statusbar.tsx
@@ -28,11 +28,12 @@ export class StatusbarClass extends React.Component<IProps> {
 
     private onClipboardCopy = () => {
         const { fileCache, appState } = this.injected;
+        const { t } = this.props;
 
         const num = appState.setClipboard(fileCache);
 
         AppToaster.show({
-            message: `${num} element(s) copied to the clipboard`,
+            message: t('COMMON.CP_COPIED', {count: num}),
             icon: "tick",
             intent: Intent.SUCCESS
         });
@@ -58,7 +59,7 @@ export class StatusbarClass extends React.Component<IProps> {
         const { t } = this.props;
 
         const pasteButton = (
-            <Tooltip content={t('STATUS.CPTOOLTIP', { numSelected })} disabled={disabled}>
+            <Tooltip content={t('STATUS.CPTOOLTIP', { count: numSelected })} disabled={disabled}>
                 <Button
                 data-cy-paste-bt
                 disabled={disabled}
@@ -75,7 +76,7 @@ export class StatusbarClass extends React.Component<IProps> {
                     disabled
                     leftIcon={iconName}
                     rightElement={pasteButton}
-                    value={`${numFiles} File(s), ${numDirs} Folder(s)`}
+                    value={`${t('STATUS.FILES', { count: numFiles })}, ${t('STATUS.FOLDERS', { count: numDirs })}`}
                     className={`status-bar ${offline}`}
                 />
             </ControlGroup>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -93,7 +93,7 @@ export class Toolbar extends React.Component<IProps, PathInputState> {
             this.input.blur();
             this.cache.cd(this.state.path)
                 .catch((err: any) => {
-                    AppAlert.show(`Error reading folder ${wrongPath} (${err.code})`, {
+                    AppAlert.show(`${err.message} (${err.code})`, {
                         intent: 'danger'
                     });
                     this.input.focus();

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -123,7 +123,7 @@ export class Toolbar extends React.Component<IProps, PathInputState> {
     }
 
     private onReload = () => {
-        this.cache.navHistory(0);
+        this.cache.reload();
     }
 
     private refHandler = (input: HTMLInputElement) => {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -109,6 +109,25 @@ button.small:hover{
     flex-grow:1;
 }
 
+.downloads.empty{
+    flex-grow: 0;
+    display: flex;
+    flex-direction: column;
+    padding-top:20%;
+}
+
+.downloads.empty .bp3-icon{
+    padding: 20px 12px;
+    border: 3px dashed #d9dde0;
+    border-radius:8px;
+    margin-bottom:20px;
+    text-align:center;
+}
+
+.downloads.empty .bp3-icon svg{
+    display:inline;
+}
+
 .downloads .bp3-tree-node-content .action{
     vertical-align:text-bottom;
     opacity: 0;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,14 +4,28 @@ import DevTools from 'mobx-react-devtools';
 import * as process from 'process';
 import { remote } from 'electron';
 import { ReactApp } from "./components/App";
-
-// declare var __PROCESS__: {
-//     env: {
-//         ci: string
-//     }
-// }
+import { I18nextProvider } from 'react-i18next';
+import i18next from './locale/i18n';
 
 declare var ENV: any;
+
+console.log(i18next.t('Hello'));
+// Development stuff: create fake directory for testing
+const exec = require('child_process').exec;
+exec('/Users/nico/tmp_ftp.sh', (err: Error) => {
+    if (err) {
+        console.log('error preparing fake folders', err);
+        if (process.platform === "win32") {
+            ReactDOM.render(
+                <ReactApp></ReactApp>,
+                document.getElementById('root'));
+        }
+    } else {
+        ReactDOM.render(
+            <I18nextProvider i18n={i18next}><ReactApp></ReactApp></I18nextProvider>,
+            document.getElementById('root'));
+    }
+});
 
 // Devlopment stuff: reload window on file change
 window.addEventListener('load', () => {
@@ -22,16 +36,3 @@ window.addEventListener('load', () => {
 });
 
 console.log(ENV.CY);
-
-// Development stuff: create fake directory for testing
-const exec = require('child_process').exec;
-exec('/Users/nico/tmp_ftp.sh', (err: Error) => {
-    if (err) {
-        console.log('error preparing fake folders', err);
-        if (process.platform === "win32") {
-            ReactDOM.render(<ReactApp></ReactApp>, document.getElementById('root'));
-        }
-    } else {
-        ReactDOM.render(<ReactApp></ReactApp>, document.getElementById('root'));
-    }
-});

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,0 +1,30 @@
+import i18next from 'i18next';
+import * as LanguageDetector from 'i18next-electron-language-detector';
+import * as en from './lang/en.json';
+import * as fr from './lang/fr.json';
+
+    i18next
+    .use(LanguageDetector)
+    .init({
+        // we init with resources
+        resources: {
+            en: en,
+            fr: fr
+        },
+        fallbackLng: 'en',
+        debug: true,
+
+        // have a common namespace used around the full app
+        ns: ['translations'],
+        defaultNS: 'translations',
+
+        interpolation: {
+            escapeValue: false, // not needed for react!!
+            formatSeparator: ','
+        },
+        react: {
+            wait: true
+        }
+    });
+
+export default i18next;

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -8,8 +8,8 @@
             "QUIT": {
                 "BT_STOP_TRANSFERS": "Cancel & quit",
                 "BT_KEEP_TRANSFERS": "Keep transfers",
-                "CONTENT": "There is <1>{{badgeSize}}</1> transfer <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> the download.",
-                "CONTENT_plural": "There are <1>{{badgeSize}}</1> transfers <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> all downloads."
+                "CONTENT": "There is <1>{{count}}</1> transfer <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> the download.",
+                "CONTENT_plural": "There are <1>{{count}}</1> transfers <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> all downloads."
             }
         },
         "SHORTCUT": {
@@ -18,11 +18,15 @@
                 "RELOAD_VIEW": "Reload current view"
             }
         },
+        "STATUS": {
+            "CPTOOLTIP": "Copy {{count}} file to the clipboard",
+            "CPTOOLTIP_plural": "Copy {{count}} files to the clipboard"
+        },
         "COMMON": {
             "Hello": "Hey there !",
             "Toto": "There are <1>{{count}}</1> transfers.",
             "SIZE": {
-                "B": "Zero byte",
+                "B": "byte",
                 "B_plural": "bytes",
                 "KB": "Kb",
                 "MB": "Mb",

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -10,6 +10,26 @@
                 "BT_KEEP_TRANSFERS": "Keep transfers",
                 "CONTENT": "There is <1>{{count}}</1> transfer <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> the download.",
                 "CONTENT_plural": "There are <1>{{count}}</1> transfers <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> all downloads."
+            },
+            "MAKEDIR": {
+                "NOT_VALID": "Folder name not valid",
+                "TITLE": "Enter a name for the new folder:",
+                "NAME": "Folder name",
+                "CREATE": "Create",
+                "CREATE_READ": "Create & read folderr"
+            },
+            "LOGIN": {
+                "TITLE": "Login to {{server}}",
+                "SERVER_NAME": "Enter server",
+                "SERVER": "server",
+                "USERNAME": "username",
+                "USERINPUT": "Enter username",
+                "HINT_USERNAME": "Leave empty for anonymous login",
+                "PASSWORD": "password",
+                "HINT_PASSWORD": "Required for non-anonymous login",
+                "PASSWORDINPUT": "Enter password",
+                "PORT": "port",
+                "LOGIN": "Login"
             }
         },
         "SHORTCUT": {
@@ -27,8 +47,6 @@
             "FOLDERS_plural": "{{count}} folders"
         },
         "COMMON": {
-            "Hello": "Hey there !",
-            "Toto": "There are <1>{{count}}</1> transfers.",
             "SIZE": {
                 "B": "byte",
                 "B_plural": "bytes",
@@ -39,7 +57,9 @@
             },
             "CP_COPIED": "{{count}} element has been copied into the clipboard",
             "CP_COPIED_plural": "{{count}} elements have been copied into the clipboard",
-            "MAKEDIR": "New Folder"
+            "MAKEDIR": "New Folder",
+            "CANCEL": "Cancel",
+            "OK": "OK"
         },
         "FILEMENU": {
             "PASTE": "Paste {{count}} item",
@@ -49,6 +69,14 @@
         },
         "DOWNLOADS": {
             "EMPTY_TITLE": "No download."
+        },
+        "ERRORS": {
+            "CANNOT_READ_FOLDER": "Cannot open '{{folder}}'",
+            "ENOTFOUND": "Server not found: check hostname",
+            "ECONNREFUSED": "Connection refused by the server",
+            "530": "Login authentication failed",
+            "UNKNOWN": "An error has occured",
+            "GENERIC": "{{message}} (code {{code}})"
         }
     }
 }

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -1,0 +1,10 @@
+{
+    "translations": {
+        "BT_STOP_TRANSFERS_QUIT": "Cancel & quit",
+        "BT_KEEP_TRANSFERS": "Keep transfers",
+        "SHORTCUT_EXIT": "Exit react-ftp",
+        "SHORTCUT_RELOAD_VIEW": "Reload current view",
+        "Hello": "Hey there !",
+        "Toto": "There are <1>{{count}}</1> transfers."
+    }
+}

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -20,7 +20,11 @@
         },
         "STATUS": {
             "CPTOOLTIP": "Copy {{count}} file to the clipboard",
-            "CPTOOLTIP_plural": "Copy {{count}} files to the clipboard"
+            "CPTOOLTIP_plural": "Copy {{count}} files to the clipboard",
+            "FILES": "{{count}} file",
+            "FILES_plural": "{{count}} files",
+            "FOLDERS": "{{count}} folder",
+            "FOLDERS_plural": "{{count}} folders"
         },
         "COMMON": {
             "Hello": "Hey there !",
@@ -32,7 +36,19 @@
                 "MB": "Mb",
                 "GB": "Gb",
                 "TB": "Tb"
-            }
+            },
+            "CP_COPIED": "{{count}} element has been copied into the clipboard",
+            "CP_COPIED_plural": "{{count}} elements have been copied into the clipboard",
+            "MAKEDIR": "New Folder"
+        },
+        "FILEMENU": {
+            "PASTE": "Paste {{count}} item",
+            "PASTE_plural": "Paste {{count}} items",
+            "DELETE": "Delete {{count}} item",
+            "DELETE_plural": "Delete {{count}} items"
+        },
+        "DOWNLOADS": {
+            "EMPTY_TITLE": "No download."
         }
     }
 }

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -1,10 +1,34 @@
 {
     "translations": {
-        "BT_STOP_TRANSFERS_QUIT": "Cancel & quit",
-        "BT_KEEP_TRANSFERS": "Keep transfers",
-        "SHORTCUT_EXIT": "Exit react-ftp",
-        "SHORTCUT_RELOAD_VIEW": "Reload current view",
-        "Hello": "Hey there !",
-        "Toto": "There are <1>{{count}}</1> transfers."
+        "NAV": {
+            "EXPLORER": "Explorer",
+            "TRANSFERS": "Transfers"
+        },
+        "DIALOG": {
+            "QUIT": {
+                "BT_STOP_TRANSFERS": "Cancel & quit",
+                "BT_KEEP_TRANSFERS": "Keep transfers",
+                "CONTENT": "There is <1>{{badgeSize}}</1> transfer <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> the download.",
+                "CONTENT_plural": "There are <1>{{badgeSize}}</1> transfers <3>in progress</3>.<5 /><6 />Exiting the app now will <8>cancel</8> all downloads."
+            }
+        },
+        "SHORTCUT": {
+            "MAIN": {
+                "QUIT": "Exit react-ftp",
+                "RELOAD_VIEW": "Reload current view"
+            }
+        },
+        "COMMON": {
+            "Hello": "Hey there !",
+            "Toto": "There are <1>{{count}}</1> transfers.",
+            "SIZE": {
+                "B": "Zero byte",
+                "B_plural": "bytes",
+                "KB": "Kb",
+                "MB": "Mb",
+                "GB": "Gb",
+                "TB": "Tb"
+            }
+        }
     }
 }

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -8,8 +8,8 @@
             "QUIT": {
                 "BT_STOP_TRANSFERS": "Arrêter & quitter",
                 "BT_KEEP_TRANSFERS": "Ne pas quitter",
-                "CONTENT": "<1>{{badgeSize}}</1> téléchargement est <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant le <8>stoppera</8>.",
-                "CONTENT_plurarl": "<1>{{badgeSize}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
+                "CONTENT": "<1>{{count}}</1> téléchargement est <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant le <8>stoppera</8>.",
+                "CONTENT_plurarl": "<1>{{count}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
             }
         },
         "SHORTCUT": {
@@ -17,6 +17,10 @@
                 "QUIT": "Quitter react-ftp",
                 "RELOAD_VIEW": "Recharger la vue"
             }
+        },
+        "STATUS": {
+            "CPTOOLTIP": "Copier {{count}} fichier dans le presse-papiers",
+            "CPTOOLTIP_plural": "Copier {{count}} fichiers dans le presse-papiers"
         },
         "COMMON": {
             "Hello": "Salut !",

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -1,0 +1,10 @@
+{
+    "translations": {
+        "BT_STOP_TRANSFERS_QUIT": "Arrêter & quitter",
+        "BT_KEEP_TRANSFERS": "Ne pas quitter",
+        "SHORTCUT_EXIT": "Quitter react-ftp",
+        "SHORTCUT_RELOAD_VIEW": "Recharger la vue",
+        "Hello": "Salut !",
+        "Toto": "Il y a <1>{{count}}</1> transferts."
+    }
+}

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -9,7 +9,7 @@
                 "BT_STOP_TRANSFERS": "Arrêter & quitter",
                 "BT_KEEP_TRANSFERS": "Ne pas quitter",
                 "CONTENT": "<1>{{count}}</1> téléchargement est <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant le <8>stoppera</8>.",
-                "CONTENT_plurarl": "<1>{{count}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
+                "CONTENT_plural": "<1>{{count}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
             }
         },
         "SHORTCUT": {
@@ -19,12 +19,17 @@
             }
         },
         "STATUS": {
-            "CPTOOLTIP": "Copier {{count}} fichier dans le presse-papiers",
-            "CPTOOLTIP_plural": "Copier {{count}} fichiers dans le presse-papiers"
+            "CPTOOLTIP": "Copier {{count}} fichier dans le presse-papier",
+            "CPTOOLTIP_plural": "Copier {{count}} fichiers dans le presse-papier",
+            "FILES": "{{count}} fichier",
+            "FILES_plural": "{{count}} fichiers",
+            "FOLDERS": "{{count}} dossier",
+            "FOLDERS_plural": "{{count}} dossiers"
         },
         "COMMON": {
             "Hello": "Salut !",
             "Toto": "Il y a <1>{{count}}</1> transferts.",
+            "Toto_plural": "Il y a <1>{{count}}</1> transfertS.",
             "SIZE": {
                 "B": "octet",
                 "B_plural": "octets",
@@ -32,7 +37,19 @@
                 "MB": "Mo",
                 "GB": "Go",
                 "TB": "To"
-            }
+            },
+            "CP_COPIED": "{{count}} élément a été copié dans le presse-papier",
+            "CP_COPIED_plural": "{{count}} éléments ont été copiés dans le presse-papier",
+            "MAKEDIR": "Nouveau dossier"
+        },
+        "FILEMENU": {
+            "PASTE": "Coller {{count}} élément",
+            "PASTE_plural": "Coller {{count}} éléments",
+            "DELETE": "Supprimer {{count}} élément",
+            "DELETE_plural": "Supprimer {{count}} éléments"
+        },
+        "DOWNLOADS": {
+            "EMPTY_TITLE": "Aucun téléchargement."
         }
     }
 }

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -1,10 +1,34 @@
 {
     "translations": {
-        "BT_STOP_TRANSFERS_QUIT": "Arrêter & quitter",
-        "BT_KEEP_TRANSFERS": "Ne pas quitter",
-        "SHORTCUT_EXIT": "Quitter react-ftp",
-        "SHORTCUT_RELOAD_VIEW": "Recharger la vue",
-        "Hello": "Salut !",
-        "Toto": "Il y a <1>{{count}}</1> transferts."
+        "NAV": {
+            "EXPLORER": "Explorateur",
+            "TRANSFERS": "Téléchargements"
+        },
+        "DIALOG": {
+            "QUIT": {
+                "BT_STOP_TRANSFERS": "Arrêter & quitter",
+                "BT_KEEP_TRANSFERS": "Ne pas quitter",
+                "CONTENT": "<1>{{badgeSize}}</1> téléchargement est <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant le <8>stoppera</8>.",
+                "CONTENT_plurarl": "<1>{{badgeSize}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
+            }
+        },
+        "SHORTCUT": {
+            "MAIN": {
+                "QUIT": "Quitter react-ftp",
+                "RELOAD_VIEW": "Recharger la vue"
+            }
+        },
+        "COMMON": {
+            "Hello": "Salut !",
+            "Toto": "Il y a <1>{{count}}</1> transferts.",
+            "SIZE": {
+                "B": "octet",
+                "B_plural": "octets",
+                "KB": "Ko",
+                "MB": "Mo",
+                "GB": "Go",
+                "TB": "To"
+            }
+        }
     }
 }

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -10,6 +10,26 @@
                 "BT_KEEP_TRANSFERS": "Ne pas quitter",
                 "CONTENT": "<1>{{count}}</1> téléchargement est <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant le <8>stoppera</8>.",
                 "CONTENT_plural": "<1>{{count}}</1> téléchargements sont <3>en cours</3>.<5 /><6 />Quiiter l'application maintenant les <8>arrêtera</8>."
+            },
+            "MAKEDIR": {
+                "NOT_VALID": "Nom de dossier non valide",
+                "TITLE": "Entrer un nom pour le nouveau dossier:",
+                "NAME": "Nom du dossier",
+                "CREATE": "Créer",
+                "CREATE_READ": "Créer & ouvrir dossier"
+            },
+            "LOGIN": {
+                "TITLE": "Connexion à {{server}}",
+                "SERVER_NAME": "Entrer le serveur",
+                "SERVER": "serveur",
+                "USERNAME": "identifiant",
+                "USERINPUT": "Saisir l'identifiant",
+                "HINT_USERNAME": "Laisser vide pour une connexion anonyme",
+                "PASSWORD": "mot de passe",
+                "HINT_PASSWORD": "Requis si connexion non anonyme",
+                "PASSWORDINPUT": "Saisir le mot de passe",
+                "PORT": "port",
+                "LOGIN": "Connexion"
             }
         },
         "SHORTCUT": {
@@ -27,9 +47,6 @@
             "FOLDERS_plural": "{{count}} dossiers"
         },
         "COMMON": {
-            "Hello": "Salut !",
-            "Toto": "Il y a <1>{{count}}</1> transferts.",
-            "Toto_plural": "Il y a <1>{{count}}</1> transfertS.",
             "SIZE": {
                 "B": "octet",
                 "B_plural": "octets",
@@ -40,7 +57,9 @@
             },
             "CP_COPIED": "{{count}} élément a été copié dans le presse-papier",
             "CP_COPIED_plural": "{{count}} éléments ont été copiés dans le presse-papier",
-            "MAKEDIR": "Nouveau dossier"
+            "MAKEDIR": "Nouveau dossier",
+            "CANCEL": "Annuler",
+            "OK": "OK"
         },
         "FILEMENU": {
             "PASTE": "Coller {{count}} élément",
@@ -50,6 +69,14 @@
         },
         "DOWNLOADS": {
             "EMPTY_TITLE": "Aucun téléchargement."
+        },
+        "ERRORS": {
+            "CANNOT_READ_FOLDER": "Impossible d'ouvrir '{{folder}}'",
+            "ENOTFOUND": "Serveur introuvable: vérifier le nom d'hôte",
+            "ECONNREFUSED": "Connexion refusée par le serveur",
+            "530": "Echec de l'authentification",
+            "UNKNOWN": "Une erreur est survenue",
+            "GENERIC": "{{error.message}} (code {{error.code}})"
         }
     }
 }

--- a/src/services/FsFtp.ts
+++ b/src/services/FsFtp.ts
@@ -8,6 +8,7 @@ import { remote } from 'electron';
 import { throttle } from '../utils/throttle';
 import { Logger, JSObject } from "../components/Log";
 import { EventEmitter } from 'events';
+import i18next from '../locale/i18n';
 
 const FtpUrl = /^(ftp\:\/\/)*(ftp\.[a-z]+\.[a-z]{2,3}|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/i;
 const ServerPart = /^(ftp\:\/\/)*(ftp\.[a-z]+\.[a-z]{2,3}|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/i;
@@ -158,14 +159,22 @@ class Client{
     private goOffline(error:any) {
         this.status = 'offline';
         if (this.readyReject) {
-            if (typeof error.code === 'string') {
+            if (typeof error.code !== 'undefined') {
                 switch (error.code) {
                     case 'ENOTFOUND':
-                        error.message = 'Server not found: check hostname';
+                        error.message = i18next.t('ERRORS.ENOTFOUND');
                         break;
 
                     case 'ECONNREFUSED':
-                        error.message = 'Connection refused by the server';
+                        error.message = i18next.t('ERRORS.ECONNREFUSED');
+                        break;
+
+                    case 530:
+                        error.message = i18next.t('ERRORS.530');
+                        break;
+
+                    default:
+                        error.message = i18next.t('ERRORS.UNKNOWN');
                         break;
                 }
             }

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -1,6 +1,7 @@
 import { observable, action, runInAction } from "mobx";
 import { FsApi, Fs, getFS, File, ICredentials } from "../services/Fs";
 import { Deferred } from '../utils/deferred';
+import i18next from '../locale/i18n';
 
 type TStatus = 'blank' | 'busy' | 'ok' | 'login' | 'offline';
 
@@ -95,7 +96,7 @@ export class FileState {
         this.server = this.prevServer;
     }
 
-    private getNewFS(path: string): Fs {
+    private getNewFS(path: string, skipContext = false): Fs {
         let newfs = getFS(path);
 
         if (newfs) {
@@ -104,7 +105,7 @@ export class FileState {
                 this.api.free();
             }
 
-            this.saveContext();
+            !skipContext && this.saveContext();
 
             this.fs = newfs;
             this.api = new newfs.API(path);
@@ -171,19 +172,22 @@ export class FileState {
         console.log('cd', path, this.path);
 
         if (this.path !== path) {
-            if (this.getNewFS(path)) {
+            if (this.getNewFS(path, skipHistory)) {
                 this.server = this.fs.serverpart(path);
                 this.credentials = this.fs.credentials(path);
             } else {
                 this.navHistory(0);
-                return Promise.reject(`Cannot open ${path}`);
+                return Promise.reject({
+                    message: i18next.t('ERRORS.CANNOT_READ_FOLDER', { folder: path }),
+                    code: 'NO_FS'
+                });
             }
         }
 
         try {
             await this.waitForConnection();
         } catch (err) {
-            return this.cd(path, path2, skipHistory);
+            return this.cd(path, path2, true);
         }
 
         const joint = path2 ? this.api.join(path, path2) : this.api.sanityze(path);

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -250,7 +250,8 @@ export class FileState {
     }
 
     reload() {
-        this.cd(this.path);
+        // this.cd(this.path);
+        this.navHistory(0);
     }
 
     join(path: string, path2: string) {

--- a/src/typings/i18next-electron-language-detector.d.ts
+++ b/src/typings/i18next-electron-language-detector.d.ts
@@ -1,0 +1,2 @@
+// i18next-electron-language-detector.d.ts
+declare module 'i18next-electron-language-detector';

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,7 +1,15 @@
 import i18next from '../locale/i18n';
 
-const translations = i18next.t('COMMON.SIZE', { returnObjects: true });
-const ByteFormats = Object.keys(translations).map((key) => translations[key]);
+let translations: any;
+let byteFormats: any;
+
+i18next.on('languageChanged', updateTranslations);
+
+export function updateTranslations() {
+    translations = i18next.t('COMMON.SIZE', { returnObjects: true });
+    byteFormats = Object.keys(translations).map((key) => translations[key]);
+    console.log('byteFormats', byteFormats);
+}
 
     // took this from stack overflow: https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
 export function formatBytes(bytes: number):string {
@@ -9,8 +17,10 @@ export function formatBytes(bytes: number):string {
     const num = (bytes / Math.pow(1024, i));
 
     if (!i) {
-        return num > 1 ? (num + ' ' + ByteFormats[1]) : (num + ' ' + ByteFormats[0]);
+        return num > 1 ? (num + ' ' + byteFormats[1]) : (num + ' ' + byteFormats[0]);
     } else {
-        return (num.toFixed(2)) + ' ' + ByteFormats[i + 1];
+        return (num.toFixed(2)) + ' ' + byteFormats[i + 1];
     }
 }
+
+updateTranslations();

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,0 +1,16 @@
+import i18next from '../locale/i18n';
+
+const translations = i18next.t('COMMON.SIZE', { returnObjects: true });
+const ByteFormats = Object.keys(translations).map((key) => translations[key]);
+
+    // took this from stack overflow: https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+export function formatBytes(bytes: number):string {
+    const i = bytes > 0 ? Math.floor(Math.log2(bytes) / 10) : 0;
+    const num = (bytes / Math.pow(1024, i));
+
+    if (!i) {
+        return num > 1 ? (num + ' ' + ByteFormats[1]) : (num + ' ' + ByteFormats[0]);
+    } else {
+        return (num.toFixed(2)) + ' ' + ByteFormats[i + 1];
+    }
+}

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -8,7 +8,6 @@ i18next.on('languageChanged', updateTranslations);
 export function updateTranslations() {
     translations = i18next.t('COMMON.SIZE', { returnObjects: true });
     byteFormats = Object.keys(translations).map((key) => translations[key]);
-    console.log('byteFormats', byteFormats);
 }
 
     // took this from stack overflow: https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
             "es2015",
             "dom"
         ],
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
- Added locale support with en+fr locale files
- Added appToaster.show can now dismiss previous toaster
- Fixed reload after connect should skip history
- Fixed cancelling login after an error would not close the login dialog
- Fixed do not render two empty divs when downloads tab is active
