### PR TITLE
Dark theme and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@
 
 ## Features
 
+**Note**
+React-FTP is still being worked on so this is a work in progress.
+
 - Plugin-based filesystem type: FTP and local supported for now
 - Can be fully keyboard controlled
 - Transfers from Local to FTP, from FTP to FTP and from local to local folders
 - Fully localized (French & English available)
+- DarkMode with automatic detection on macOS Mojave
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ftpd": "ftp-srv ftp://0.0.0.0:9876 --root /tmp/react-explorer -c ./credentials.json"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@types/del": "^3.0.1",
     "@types/i18next": "^12.1.0",
@@ -52,8 +52,6 @@
     "ftp-ts": "^1.0.19",
     "get-folder-size": "^2.0.0",
     "i18next": "^13.0.0",
-    "i18next-browser-languagedetector": "^2.2.4",
-    "i18next-electron-language-detector": "0.0.10",
     "mkdirp": "^0.5.1",
     "mobx": "^3.2.1",
     "mobx-react": "^4.2.2",
@@ -61,7 +59,6 @@
     "npm": "^6.5.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
-    "react-i18next": "^8.4.0",
-    "uninstall": "0.0.0"
+    "react-i18next": "^8.4.0"
   }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -76,6 +76,13 @@ class App extends React.Component<WithNamespaces, IState> {
 
     showDownloadsTab = () => {
         this.appState.isExplorer = false;
+        // right now lister's selection is lost because
+        // switching to downloads destroys the listers
+        // and switching back to explorer view creates
+        // new listers, which in turns creates new nodes
+        // fixing this require a little work so meanwhile
+        // this correctly resets the cache's state
+        this.appState.clearSelections();
     }
 
     showExplorerTab = () => {
@@ -83,7 +90,11 @@ class App extends React.Component<WithNamespaces, IState> {
     }
 
     navClick = () => {
-        this.appState.isExplorer = !this.appState.isExplorer;
+        if (this.appState.isExplorer) {
+            this.showDownloadsTab();
+        } else {
+            this.showExplorerTab();
+        }
     }
 
     setActiveView(view:number) {
@@ -304,6 +315,10 @@ class App extends React.Component<WithNamespaces, IState> {
         });
     }
 
+    toggleDarkMode = () => {
+        document.body.classList.toggle('bp3-dark');
+    }
+
     private getActiveFileCache(ignoreStatus = false): FileState {
         const state = this.appState.getActiveCache();
 
@@ -393,7 +408,7 @@ class App extends React.Component<WithNamespaces, IState> {
                         </Navbar.Group>
                         <Navbar.Group align={Alignment.RIGHT}>
                             <Navbar.Divider />
-                            <Button className="bp3-minimal" onClick={this.changeLanguage} icon="cog" />
+                            <Button className="bp3-minimal" onClick={this.toggleDarkMode} icon="cog" />
                         </Navbar.Group>
                     </Navbar>
                     <div onClickCapture={this.handleClick} className="main">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,7 @@ import { AppState } from "../state/appState";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { FocusStyleManager, Icon, HotkeysTarget, Hotkeys, Hotkey, Alert } from "@blueprintjs/core";
-import { Provider, observer } from "mobx-react";
+import { Provider, observer, inject } from "mobx-react";
 import { Navbar, Alignment, Button, Intent } from "@blueprintjs/core";
 import { SideView } from "./SideView";
 import { LogUI, Logger } from "./Log";
@@ -15,6 +15,7 @@ import * as process from 'process';
 import { remote } from 'electron';
 import i18next from '../locale/i18n';
 import { FileState } from "../state/fileState";
+import { SettingsState } from "../state/settingsState";
 
 require("@blueprintjs/core/lib/css/blueprint.css");
 require("@blueprintjs/icons/lib/css/blueprint-icons.css");
@@ -23,6 +24,10 @@ require("../css/main.css");
 interface IState {
     // activeView: number;
     isExitDialogOpen: boolean;
+}
+
+interface InjectedProps extends WithNamespaces{
+    settingsState:SettingsState
 }
 
 const EXIT_DELAY = 1200;
@@ -37,6 +42,7 @@ declare global {
     }
 }
 
+@inject('settingsState')
 @observer
 @HotkeysTarget
 class App extends React.Component<WithNamespaces, IState> {
@@ -45,8 +51,15 @@ class App extends React.Component<WithNamespaces, IState> {
     private exitTimeout: any = 0;
     private exitMode = false;
 
+    private get injected() {
+        return this.props as InjectedProps;
+    }
+
     constructor(props: WithNamespaces) {
         super(props);
+
+        console.log(this.injected.settingsState.lang);
+        debugger;
 
         this.state = { isExitDialogOpen: false };
 
@@ -307,16 +320,14 @@ class App extends React.Component<WithNamespaces, IState> {
     }
 
     changeLanguage = () => {
-        console.log('changing language to en');
-        i18next.changeLanguage('en', (err, t2) => {
-            if (err) {
-                console.warn('oops, error changing language to en', err);
-            }
-        });
+        const { settingsState } = this.injected;
+        settingsState.setLanguage('en');
     }
 
     toggleDarkMode = () => {
-        document.body.classList.toggle('bp3-dark');
+        // document.body.classList.toggle('bp3-dark');
+        const { settingsState } = this.injected;
+        settingsState.darkMode = true;
     }
 
     private getActiveFileCache(ignoreStatus = false): FileState {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -59,7 +59,6 @@ class App extends React.Component<WithNamespaces, IState> {
         super(props);
 
         console.log(this.injected.settingsState.lang);
-        debugger;
 
         this.state = { isExitDialogOpen: false };
 
@@ -140,15 +139,6 @@ class App extends React.Component<WithNamespaces, IState> {
         return shouldCancel;
     }
 
-    // shouldComponentUpdate() {
-    //     console.time('App Render');
-    //     return true;
-    // }
-
-    // componentDidUpdate() {
-    //     console.timeEnd('App Render');
-    // }
-
     onExitComboDown = (e: KeyboardEvent) => {
         const { t } = this.props;
 
@@ -188,6 +178,11 @@ class App extends React.Component<WithNamespaces, IState> {
     componentDidMount() {
         // listen for events from main process
         this.addListeners();
+        this.setDarkTheme();
+    }
+
+    componentDidUpdate() {
+        this.setDarkTheme();
     }
 
     onExitDialogClose = (valid:boolean) => {
@@ -325,7 +320,7 @@ class App extends React.Component<WithNamespaces, IState> {
     }
 
     toggleDarkMode = () => {
-        // document.body.classList.toggle('bp3-dark');
+        document.body.classList.toggle('bp3-dark');
         const { settingsState } = this.injected;
         settingsState.darkMode = true;
     }
@@ -384,14 +379,30 @@ class App extends React.Component<WithNamespaces, IState> {
         }
     }
 
+    setDarkTheme() {
+        const { settingsState } = this.injected;
+        if (settingsState.isDarkModeActive) {
+            document.body.classList.add('bp3-dark');
+        } else {
+            document.body.classList.remove('bp3-dark');
+        }
+    }
+
     render() {
         const { /*isExplorer,*/ /*activeView,*/ isExitDialogOpen } = this.state;
+        const { settingsState } = this.injected;
         const isExplorer = this.appState.isExplorer;
         const count = this.appState.pendingTransfers;
         const badgeText = count && (count + '') || '';
         const badgeProgress = this.appState.totalTransferProgress;
         const { t } = this.props;
         const caches = this.appState.caches;
+
+        // Access isDarkModeActive without modifying it to make mobx trigger the render
+        // when isDarkModeActive is modified.
+        // We could modify the body's class from here but it's a bad pratice so we
+        // do it in componentDidUpdate/componentDidMount instead
+        settingsState.isDarkModeActive;
 
         return (
             <Provider appState={this.appState}>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -534,7 +534,10 @@ export class FileListClass extends React.Component<IProps, FileListState> {
         //         </div>
         //     );
         // } else {
-            console.log('**render');
+        console.log('**render FileList');
+        if (this.state.nodes.length) {
+            console.log('node 1 is', this.state.nodes[1].isSelected);
+        }
             return (
                 <div className="filelist" onKeyUp={this.onInputKeyUp} onKeyDown={this.onInputKeyDown}>
                     <Tree

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -534,10 +534,6 @@ export class FileListClass extends React.Component<IProps, FileListState> {
         //         </div>
         //     );
         // } else {
-        console.log('**render FileList');
-        if (this.state.nodes.length) {
-            console.log('node 1 is', this.state.nodes[1].isSelected);
-        }
             return (
                 <div className="filelist" onKeyUp={this.onInputKeyUp} onKeyDown={this.onInputKeyDown}>
                     <Tree

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -170,6 +170,10 @@ button.small:hover{
     text-align: center;
 }
 
+.bp3-dark .bp3-badge-content {
+    color: #48aff0;
+}
+
 .bp3-badge .bp3-spinner{
     display:inline-block;
 }
@@ -188,6 +192,22 @@ button.small:hover{
 
 .bp3-badge.bp3-intent-warning{
     background-color:#bf7326;
+}
+
+.bp3-dark .bp3-badge.bp3-intent-success{
+    background-color:#0f9960;
+}
+
+.bp3-dark .bp3-badge.bp3-intent-danger{
+    background-color:#db3737;
+}
+
+.bp3-dark .bp3-badge.bp3-intent-primary{
+    background-color:#137cbd;
+}
+
+.bp3-dark .bp3-badge.bp3-intent-warning{
+    background-color:#d9822b;
 }
 
 /* active lister */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -5,7 +5,8 @@ body{
     user-select: none;
 }
 
-.bp3-dark {
+body.bp3-dark {
+    background-color: #293742;
     color: #f5f8fa;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,23 +6,72 @@ import { remote } from 'electron';
 import { ReactApp } from "./components/App";
 import { I18nextProvider } from 'react-i18next';
 import i18next from './locale/i18n';
+import { SettingsState } from "./state/settingsState";
+import { Provider } from "mobx-react";
 
-// Development stuff: create fake directory for testing
-const exec = require('child_process').exec;
-exec('/Users/nico/tmp_ftp.sh', (err: Error) => {
-    if (err) {
-        console.log('error preparing fake folders', err);
+class App {
+    settingsState: SettingsState;
+
+    constructor() {
+        this.settingsState = new SettingsState();
+        this.createTestFolder().then(this.renderApp);
     }
 
-    ReactDOM.render(
-        <I18nextProvider i18n={i18next}><ReactApp></ReactApp></I18nextProvider>,
-        document.getElementById('root'));    
-});
+    // debug stuff
+    createTestFolder():Promise<any> {
+        return new Promise((resolve, reject) => {
+            // Development stuff: create fake directory for testing
+            const exec = require('child_process').exec;
+            exec('/Users/nico/tmp_ftp.sh', (err: Error) => {
+                if (err) {
+                    console.log('error preparing fake folders', err);
+                }
 
-// Devlopment stuff: reload window on file change
-window.addEventListener('load', () => {
-    const btn: HTMLButtonElement = document.querySelector('#reload');
-    btn.addEventListener('click', () => {
-        remote.getCurrentWebContents().reloadIgnoringCache();
-    });
-});
+                resolve();
+            });
+        })
+    }
+
+    renderApp = () => {
+        ReactDOM.render(
+            <I18nextProvider i18n={i18next}>
+                <Provider settingsState={this.settingsState}>
+                    <ReactApp></ReactApp>
+                </Provider>
+            </I18nextProvider>,
+            document.getElementById('root'));
+    }
+
+    addListeners() {
+        // Devlopment stuff: reload window on file change
+        window.addEventListener('load', () => {
+            const btn: HTMLButtonElement = document.querySelector('#reload');
+            btn.addEventListener('click', () => {
+                remote.getCurrentWebContents().reloadIgnoringCache();
+            });
+
+            if (isDarkMode()) {
+
+            }
+        });
+    }
+}
+
+const app = new App();
+
+let isDarkMode: () => boolean;
+
+function addOSSpecificStuff() {
+    switch (process.platform) {
+        case 'darwin':
+            addMacHandlers();
+            break;
+    }
+}
+
+function addMacHandlers() {
+    const { systemPreferences } = remote;
+    isDarkMode = function () {
+        return systemPreferences.isDarkMode();
+    }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,29 +49,8 @@ class App {
             btn.addEventListener('click', () => {
                 remote.getCurrentWebContents().reloadIgnoringCache();
             });
-
-            if (isDarkMode()) {
-
-            }
         });
     }
 }
 
 const app = new App();
-
-let isDarkMode: () => boolean;
-
-function addOSSpecificStuff() {
-    switch (process.platform) {
-        case 'darwin':
-            addMacHandlers();
-            break;
-    }
-}
-
-function addMacHandlers() {
-    const { systemPreferences } = remote;
-    isDarkMode = function () {
-        return systemPreferences.isDarkMode();
-    }
-}

--- a/src/state/appState.ts
+++ b/src/state/appState.ts
@@ -149,6 +149,13 @@ export class AppState {
         cache.selected.replace(newSelection);
     }
 
+    @action
+    clearSelections() {
+        for (let cache of this.caches) {
+            cache.clearSelection();
+        }
+    }
+
     // global
     @observable
     clipboard: Clipboard = {

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -243,7 +243,7 @@ export class FileState {
                     console.log('run in actions', this.path);
                     this.files.replace(files);
                     // clear lister selection as well
-                    this.selected.clear();
+                    this.clearSelection();
                     // TODO: sync caches ?
 
                     this.status = 'ok';
@@ -251,6 +251,10 @@ export class FileState {
 
                 return files;
             });
+    }
+
+    @action clearSelection() {
+        this.selected.clear();
     }
 
     reload() {

--- a/src/state/settingsState.ts
+++ b/src/state/settingsState.ts
@@ -1,22 +1,42 @@
 import { observable, action } from "mobx";
 import { remote } from 'electron';
-import * as process from 'process';
+import { release } from 'os';
+import { platform } from 'process';
 import { JSObject } from "../components/Log";
 import i18next from '../locale/i18n';
+
+const { systemPreferences } = remote;
+
+const APP_STORAGE_KEY = 'react-ftp';
+const IS_MOJAVE = platform === 'darwin' && ((parseInt(release().split('.')[0], 10) - 4) >= 14);
 
 export class SettingsState {
     @observable
     lang:string;
 
     @observable
-    darkMode:boolean;
+    // this is the asked mode
+    darkMode:boolean | 'auto';
+
+    // this is the current active mode
+    @observable
+    isDarkModeActive: boolean;
 
     @observable
     defaultFolder:string;
 
     constructor() {
+        this.installListeners();
         this.loadSettings();
+        this.setActiveTheme();
         this.setLanguage(this.lang);
+    }
+
+    installListeners() {
+        systemPreferences.subscribeNotification(
+            'AppleInterfaceThemeChangedNotification',
+            this.setActiveTheme
+        );
     }
 
     getParam(name: string):JSObject {
@@ -47,6 +67,14 @@ export class SettingsState {
         this.saveSettings();
     }
 
+    @action
+    onThemeChange(isDarkMode: boolean) {
+        // only react to OS theme change if darkMode is set to auto
+        if (this.darkMode === 'auto') {
+            this.isDarkModeActive = isDarkMode;
+        }
+    }
+
     saveSettings() {
         localStorage.setItem('react-ftp', JSON.stringify({
             lang: this.lang,
@@ -59,9 +87,7 @@ export class SettingsState {
     loadSettings():void {
         let settings: JSObject;
 
-        debugger;
-
-        settings = this.getParam('react-ftp');
+        settings = this.getParam(APP_STORAGE_KEY);
 
         // no settings set: first time the app is run
         if (settings === null) {
@@ -70,14 +96,29 @@ export class SettingsState {
 
         this.lang = settings.lang;
         this.darkMode = settings.darkMode;
+        this.setActiveTheme();
         this.defaultFolder = settings.defaultFolder;
+    }
+
+    @action
+    setActiveTheme = () => {
+        if (this.darkMode === 'auto') {
+            this.isDarkModeActive = systemPreferences.isDarkMode();
+        } else {
+            this.isDarkModeActive = this.darkMode;
+        }
     }
 
     getDefaultSettings() {
         return {
             lang: 'auto',
-            darkMode: false,
-            defaultFolder: process.platform === "win32" ? remote.app.getPath('temp') : '/tmp/react-explorer'
+            darkMode: IS_MOJAVE ? 'auto' : false,
+            defaultFolder: platform === "win32" ? remote.app.getPath('temp') : '/tmp/react-explorer'
         }
+    }
+
+    @action
+    resetSettings() {
+        localStorage.removeItem(APP_STORAGE_KEY);
     }
 }

--- a/src/state/settingsState.ts
+++ b/src/state/settingsState.ts
@@ -1,0 +1,83 @@
+import { observable, action } from "mobx";
+import { remote } from 'electron';
+import * as process from 'process';
+import { JSObject } from "../components/Log";
+import i18next from '../locale/i18n';
+
+export class SettingsState {
+    @observable
+    lang:string;
+
+    @observable
+    darkMode:boolean;
+
+    @observable
+    defaultFolder:string;
+
+    constructor() {
+        this.loadSettings();
+        this.setLanguage(this.lang);
+    }
+
+    getParam(name: string):JSObject {
+        return JSON.parse(localStorage.getItem(name));
+    }
+
+    @action
+    setLanguage(askedLang: string) {
+        let lang = askedLang;
+
+        // detect language from host OS if set to auto
+        if (lang === 'auto') {
+            lang = remote.app.getLocale();
+        }
+
+        // check we support this language
+        if (i18next.languages.indexOf(lang) < -1) {
+            lang = 'en';
+        }
+
+        // finally set requested language
+        i18next.changeLanguage(lang);
+
+        console.log('setting language to', lang);
+
+        this.lang = askedLang;
+
+        this.saveSettings();
+    }
+
+    saveSettings() {
+        localStorage.setItem('react-ftp', JSON.stringify({
+            lang: this.lang,
+            defaultFolder: this.defaultFolder,
+            darkMode: this.darkMode
+        }));
+    }
+
+    @action
+    loadSettings():void {
+        let settings: JSObject;
+
+        debugger;
+
+        settings = this.getParam('react-ftp');
+
+        // no settings set: first time the app is run
+        if (settings === null) {
+            settings = this.getDefaultSettings();
+        }
+
+        this.lang = settings.lang;
+        this.darkMode = settings.darkMode;
+        this.defaultFolder = settings.defaultFolder;
+    }
+
+    getDefaultSettings() {
+        return {
+            lang: 'auto',
+            darkMode: false,
+            defaultFolder: process.platform === "win32" ? remote.app.getPath('temp') : '/tmp/react-explorer'
+        }
+    }
+}


### PR DESCRIPTION
This pull-request adds:
 * global app settings settingsState with the following properties:
  - lang: `string` = 'auto'
  - darkMode: `boolean | 'auto'` = 'auto' (macOS Mojave) | false
  - defaultFolder: `string` = `userPath`
 * darkMode handling with automatic detection on Mojave (if darkMode is set to `auto`)

A long-standing bug when switching to downloads was also fixed.  